### PR TITLE
Extensions for FluentResults + FluentAssertions during testing

### DIFF
--- a/MLib3.sln
+++ b/MLib3.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MLib3.Localization.Abstract
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MLib3.Localization.UnitTests", "tests\MLib3.Localization.UnitTests\MLib3.Localization.UnitTests.csproj", "{1E5203CB-97DC-488B-B87F-769933948208}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MLib3.FluentResults.Extensions.FluentAssertions", "src\MLib3.FluentResults.Extensions.FluentAssertions\MLib3.FluentResults.Extensions.FluentAssertions.csproj", "{70BEBE47-555C-42C5-BE26-C1233BC84731}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,7 @@ Global
 		{6035EA21-9174-475E-8B68-8EEBD9E63AD7} = {DCE20467-1952-4C22-B2A4-4A1145AF5B89}
 		{8CBE7DE6-5A9D-467F-B265-BE1C2E6F8316} = {DCE20467-1952-4C22-B2A4-4A1145AF5B89}
 		{1E5203CB-97DC-488B-B87F-769933948208} = {7D70D635-7644-447C-A7FB-58293833BB8C}
+		{70BEBE47-555C-42C5-BE26-C1233BC84731} = {DCE20467-1952-4C22-B2A4-4A1145AF5B89}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FC79F919-ACE3-4D14-BEE4-2D95F6499915}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -117,5 +120,9 @@ Global
 		{1E5203CB-97DC-488B-B87F-769933948208}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E5203CB-97DC-488B-B87F-769933948208}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E5203CB-97DC-488B-B87F-769933948208}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70BEBE47-555C-42C5-BE26-C1233BC84731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70BEBE47-555C-42C5-BE26-C1233BC84731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70BEBE47-555C-42C5-BE26-C1233BC84731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70BEBE47-555C-42C5-BE26-C1233BC84731}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/MLib3.FluentResults.Extensions.FluentAssertions/ErrorAssertions.cs
+++ b/src/MLib3.FluentResults.Extensions.FluentAssertions/ErrorAssertions.cs
@@ -1,0 +1,17 @@
+﻿using FluentAssertions.Primitives;
+using FluentResults;
+using FluentResults.Extensions.FluentAssertions;
+
+namespace MLib3.FluentResults.Extensions.FluentAssertions;
+
+public class ErrorAssertions : ReferenceTypeAssertions<IError, ErrorAssertions>
+{
+    public ErrorAssertions(IError subject) : base(subject) { }
+
+    protected override string Identifier => nameof(IError);
+    
+    public AndWhichThatConstraint<ErrorAssertions, IError, ErrorAssertions> MatchError(string message, string because = "", params object[] becauseArgs)
+    { 
+        return new MatchErrorSubAssertionOperator().Do(Subject, this, message, MessageComparisonLogics.ActualContainsExpected, because, becauseArgs);
+    }
+}

--- a/src/MLib3.FluentResults.Extensions.FluentAssertions/MLib3.FluentResults.Extensions.FluentAssertions.csproj
+++ b/src/MLib3.FluentResults.Extensions.FluentAssertions/MLib3.FluentResults.Extensions.FluentAssertions.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Title>MLib3.FluentResults.Extensions.FluentAssertions</Title>
+        <Authors>Andreas Naumann</Authors>
+        <Description>These extensions for FluentResults allow simple matches to parts of an error (and not the complete error) while working with xUnit and FluentAssertions. The FluentResults.Extensions.FluentAssertions are not enough for this.</Description>
+        <Copyright>2023 @ WITTENSTEIN SE</Copyright>
+        <PackageIcon>icon.png</PackageIcon>
+        <RepositoryUrl>https://github.com/mrmorrandir/MLib3</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>FluentResults;Extensions;FluentAssertions;xUnit;Tests;UnitTests;</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="..\..\assets\icon.png">
+        <Pack>True</Pack>
+        <PackagePath></PackagePath>
+        <Link>icon.png</Link>
+      </None>
+    </ItemGroup>
+
+</Project>

--- a/src/MLib3.FluentResults.Extensions.FluentAssertions/MatchErrorAssertionOperator.cs
+++ b/src/MLib3.FluentResults.Extensions.FluentAssertions/MatchErrorAssertionOperator.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions.Execution;
+using FluentResults;
+using FluentResults.Extensions.FluentAssertions;
+
+namespace MLib3.FluentResults.Extensions.FluentAssertions;
+
+internal class MatchErrorAssertionOperator
+{
+    public AndWhichThatConstraint<TResultAssertion, TResult, ErrorAssertions> Do<TResultAssertion, TResult>(TResult subject, TResultAssertion parentConstraint, string expectedMessage, Func<string, string, bool> messageComparison, string because, params object[] becauseArgs)
+        where TResult : ResultBase
+    {
+        messageComparison = messageComparison ?? FluentResultAssertionsConfig.MessageComparison;
+
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .Given(() => subject.Errors)
+            .ForCondition(errors => errors.Any(reason => messageComparison(reason.Message, expectedMessage)))
+            .FailWith("Expected result to contain error with message containing {0}, but found error '{1}'", expectedMessage, subject.Errors);
+
+        return new AndWhichThatConstraint<TResultAssertion, TResult, ErrorAssertions>(parentConstraint, subject, new ErrorAssertions(subject.Errors.SingleOrDefault(reason => messageComparison(reason.Message, expectedMessage))));
+    }
+}

--- a/src/MLib3.FluentResults.Extensions.FluentAssertions/MatchErrorSubAssertionOperator.cs
+++ b/src/MLib3.FluentResults.Extensions.FluentAssertions/MatchErrorSubAssertionOperator.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions.Execution;
+using FluentResults;
+using FluentResults.Extensions.FluentAssertions;
+
+namespace MLib3.FluentResults.Extensions.FluentAssertions;
+
+internal class MatchErrorSubAssertionOperator
+{
+    public AndWhichThatConstraint<TError, TResult, ErrorAssertions> Do<TError, TResult>(TResult subject, TError parentConstraint, string expectedMessage, Func<string, string, bool> messageComparison, string because, params object[] becauseArgs)
+        where TResult : IError
+    {
+        messageComparison = messageComparison ?? FluentResultAssertionsConfig.MessageComparison;
+
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .Given(() => subject.Reasons)
+            .ForCondition(errors => errors.Any(reason => messageComparison(reason.Message, expectedMessage)))
+            .FailWith("Expected error to contain error with message containing {0}, but found error '{1}'", expectedMessage, subject.Reasons);
+
+        return new AndWhichThatConstraint<TError, TResult, ErrorAssertions>(parentConstraint, subject, new ErrorAssertions(subject.Reasons.SingleOrDefault(reason => messageComparison(reason.Message, expectedMessage))));
+    }
+}

--- a/src/MLib3.FluentResults.Extensions.FluentAssertions/ResultExtensions.cs
+++ b/src/MLib3.FluentResults.Extensions.FluentAssertions/ResultExtensions.cs
@@ -1,0 +1,17 @@
+﻿using FluentResults;
+using FluentResults.Extensions.FluentAssertions;
+
+namespace MLib3.FluentResults.Extensions.FluentAssertions;
+
+public static class ResultExtensions 
+{
+    public static AndWhichThatConstraint<ResultAssertions, Result, ErrorAssertions> MatchError(this ResultAssertions resultAssertions, string message, string because = "", params object[] becauseArgs)
+    {
+        return new MatchErrorAssertionOperator().Do(resultAssertions.Subject, resultAssertions, message, MessageComparisonLogics.ActualContainsExpected, because, becauseArgs);
+    }
+    
+    public static AndWhichThatConstraint<ResultAssertions<TResult>, Result<TResult>, ErrorAssertions> MatchError<TResult>(this ResultAssertions<TResult> resultAssertions, string message, string because = "", params object[] becauseArgs)
+    {
+        return new MatchErrorAssertionOperator().Do(resultAssertions.Subject, resultAssertions, message, MessageComparisonLogics.ActualContainsExpected, because, becauseArgs);
+    }
+}


### PR DESCRIPTION
These extensions for FluentResults allow simple matches to parts of an error (and not the complete error) while working with xUnit and FluentAssertions. The FluentResults.Extensions.FluentAssertions are not enough for this.