### PR TITLE
Merge 23-clean-commands-from-ifluentreactionapi into main

### DIFF
--- a/src/MLib3.MVVM/Commands/AsyncCommand.cs
+++ b/src/MLib3.MVVM/Commands/AsyncCommand.cs
@@ -5,12 +5,12 @@ namespace MLib3.MVVM
     /// <summary>
     /// AsyncCommand is used whenever an async operation with async/await should be used within the <see cref="ICommand.Execute(object)"/> body. A <see cref="DelegateCommand"/> is not sufficient for async operations!
     /// </summary>
-    public class AsyncCommand : AsyncCommand<object>
+    public class AsyncCommand : AsyncCommand<object?>
     {
-        public AsyncCommand(Func<object, Task> execute, Action<Exception> errorCallback) : base(execute, errorCallback)
+        public AsyncCommand(Func<object?, Task> execute, Action<Exception> errorCallback) : base(execute, errorCallback)
         {
         }
-        public AsyncCommand(Func<object, Task> execute, Func<object, bool> canExecute, Action<Exception> errorCallback) : base(execute, canExecute, errorCallback)
+        public AsyncCommand(Func<object?, Task> execute, Func<object?, bool> canExecute, Action<Exception> errorCallback) : base(execute, canExecute, errorCallback)
         {
         }
     }

--- a/src/MLib3.MVVM/Commands/AsyncCommand[T].cs
+++ b/src/MLib3.MVVM/Commands/AsyncCommand[T].cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-using System.Reflection;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace MLib3.MVVM
 {
@@ -60,7 +58,5 @@ namespace MLib3.MVVM
             if (CanExecute((T)parameter!))
                 await ExecuteAsync((T)parameter!).ConfigureAwait(true);
         }
-
-        
     }
 }

--- a/src/MLib3.MVVM/Commands/DelegateCommand.cs
+++ b/src/MLib3.MVVM/Commands/DelegateCommand.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Input;
-
-namespace MLib3.MVVM
+﻿namespace MLib3.MVVM
 {
     public class DelegateCommand : DelegateCommand<object>
     {

--- a/src/MLib3.MVVM/Commands/DelegateCommand[T].cs
+++ b/src/MLib3.MVVM/Commands/DelegateCommand[T].cs
@@ -1,20 +1,16 @@
-﻿using System.ComponentModel;
-using System.Reflection;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace MLib3.MVVM
 {
     public class DelegateCommand<T> : ICommandBase
     {
-        private readonly Func<T, bool> _canExecute;
-        private readonly Action<T> _execute;
-        private Dictionary<object, List<string>> _dependsOn;
+        private readonly Func<T?, bool> _canExecute;
+        private readonly Action<T?> _execute;
 
         public DelegateCommand(Action<T?> execute, Func<T?, bool>? canExecute = null)
         {
             _execute = execute;
             _canExecute = canExecute ?? (_ => true);
-            _dependsOn = new Dictionary<object, List<string>>();
         }
 
         public bool CanExecute(T? parameter = default)

--- a/src/MLib3.MVVM/Commands/ICommandBase.cs
+++ b/src/MLib3.MVVM/Commands/ICommandBase.cs
@@ -1,11 +1,4 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.Design;
-using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace MLib3.MVVM;
 

--- a/src/MLib3.MVVM/Commands/ReactionApi/PropertyChangedHandler[TCommand, TRootSource, TSource, TProperty].cs
+++ b/src/MLib3.MVVM/Commands/ReactionApi/PropertyChangedHandler[TCommand, TRootSource, TSource, TProperty].cs
@@ -1,7 +1,5 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.Design;
 using System.Linq.Expressions;
-using System.Reflection.Metadata;
 
 namespace MLib3.MVVM;
 

--- a/src/MLib3.MVVM/ViewModel(T).cs
+++ b/src/MLib3.MVVM/ViewModel(T).cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace MLib3.MVVM;
 
@@ -12,7 +11,7 @@ public abstract class ViewModel<TModel> : ViewModel, IViewModel<TModel> where TM
         Model = model ?? throw new ArgumentNullException(nameof(model));
     }
     
-    protected virtual void SetModel<TValue>(TValue? value, ValueChangedCallback<TValue?>? callback = null, [CallerMemberName] string property = null)
+    protected virtual void SetModel<TValue>(TValue? value, ValueChangedCallback<TValue?>? callback = null, [CallerMemberName] string? property = null)
     {
         if (property is null) throw new ArgumentNullException(nameof(property));
         var propertyInfo = Model.GetType().GetProperty(property);

--- a/tests/MLib3.MVVM.UnitTests/Mocks/A.cs
+++ b/tests/MLib3.MVVM.UnitTests/Mocks/A.cs
@@ -4,7 +4,7 @@ namespace MLib3.MVVM.UnitTests.Mocks;
 
 public class A : INotifyPropertyChanged
 {
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private B _b = new B();
     public B B

--- a/tests/MLib3.MVVM.UnitTests/Mocks/B.cs
+++ b/tests/MLib3.MVVM.UnitTests/Mocks/B.cs
@@ -4,7 +4,7 @@ namespace MLib3.MVVM.UnitTests.Mocks;
 
 public class B : INotifyPropertyChanged
 {
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private C _c = new C();
     public C C

--- a/tests/MLib3.MVVM.UnitTests/Mocks/C.cs
+++ b/tests/MLib3.MVVM.UnitTests/Mocks/C.cs
@@ -4,7 +4,7 @@ namespace MLib3.MVVM.UnitTests.Mocks;
 
 public class C : INotifyPropertyChanged
 {
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private string _name = nameof(C);
     public string Name


### PR DESCRIPTION
Cleaned the commands from the remaining old ReactionApis (there was noch much left). Adjusted some smaller details to get rid of compiler warnings for MVVM and MVVM.UnitTests.