### PR TITLE
Update package dependencies and project versions across libraries and…

### DIFF
--- a/src/MLib3.Protocols.Measurements.Serialization.Json/MLib3.Protocols.Measurements.Serialization.Json.csproj
+++ b/src/MLib3.Protocols.Measurements.Serialization.Json/MLib3.Protocols.Measurements.Serialization.Json.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <Title>MLib3.Protocols.Measurements.Serialization.Json</Title>
         <Authors>Andreas Naumann</Authors>
         <Copyright>2025 @ Andreas Naumann</Copyright>
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentResults" Version="3.16.0" />
+      <PackageReference Include="FluentResults" Version="4.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     </ItemGroup>
 

--- a/src/MLib3.Protocols.Measurements.Serialization.Xml/MLib3.Protocols.Measurements.Serialization.Xml.csproj
+++ b/src/MLib3.Protocols.Measurements.Serialization.Xml/MLib3.Protocols.Measurements.Serialization.Xml.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <Title>MLib3.Protocols.Measurements.Serialization.Xml</Title>
         <Authors>Andreas Naumann</Authors>
         <Copyright>2025 @ Andreas Naumann</Copyright>
@@ -21,6 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentResults" Version="4.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
       <PackageReference Include="Scrutor" Version="5.0.1" />
       <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="21.0.29" />

--- a/src/MLib3.Protocols.Measurements.Serialization/MLib3.Protocols.Measurements.Serialization.csproj
+++ b/src/MLib3.Protocols.Measurements.Serialization/MLib3.Protocols.Measurements.Serialization.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <Title>MLib3.Protocols.Measurements.Serialization</Title>
         <Authors>Andreas Naumann, Philipp Köhler</Authors>
         <Copyright>2025 @ Andreas Naumann</Copyright>
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentResults" Version="3.16.0" />
+      <PackageReference Include="FluentResults" Version="4.0.0" />
       <PackageReference Include="System.Text.Json" Version="9.0.4" />
     </ItemGroup>
 

--- a/tests/MLib3.Protocols.Measurements.Serialization.Json.UnitTests/MLib3.Protocols.Measurements.Serialization.Json.UnitTests.csproj
+++ b/tests/MLib3.Protocols.Measurements.Serialization.Json.UnitTests/MLib3.Protocols.Measurements.Serialization.Json.UnitTests.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.4" />
-        <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.2" />
+        <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.2.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>

--- a/tests/MLib3.Protocols.Measurements.Serialization.Xml.UnitTests/MLib3.Protocols.Measurements.Serialization.Xml.UnitTests.csproj
+++ b/tests/MLib3.Protocols.Measurements.Serialization.Xml.UnitTests/MLib3.Protocols.Measurements.Serialization.Xml.UnitTests.csproj
@@ -12,8 +12,8 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
-        <PackageReference Include="FluentResults" Version="3.16.0" />
-        <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.2" />
+        <PackageReference Include="FluentResults" Version="4.0.0" />
+        <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.2.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>


### PR DESCRIPTION
… tests

- Updated FluentResults to 4.0.0 from 3.16.0 because of breaking change