### PR TITLE
feat(build): update API key parameter handling in build scripts

### DIFF
--- a/build-nuget-mlib3-aspdotnet-apikeys-abstractions.ps1
+++ b/build-nuget-mlib3-aspdotnet-apikeys-abstractions.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.AspDotNet.ApiKeys.Abstractions/MLib3.AspDotNet.ApiKeys.Abstractions.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-aspdotnet-apikeys.ps1
+++ b/build-nuget-mlib3-aspdotnet-apikeys.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.AspDotNet.ApiKeys/MLib3.AspDotNet.ApiKeys.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-aspnetcore-dockercompose.ps1
+++ b/build-nuget-mlib3-aspnetcore-dockercompose.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.AspNetCore.DockerCompose/MLib3.AspNetCore.DockerCompose.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-communication-messagebroker-abstractions.ps1
+++ b/build-nuget-mlib3-communication-messagebroker-abstractions.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Communication.MessageBroker.Abstractions/MLib3.Communication.MessageBroker.Abstractions.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-communication-messagebroker.ps1
+++ b/build-nuget-mlib3-communication-messagebroker.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Communication.MessageBroker/MLib3.Communication.MessageBroker.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-mvvm-abstractions.ps1
+++ b/build-nuget-mlib3-mvvm-abstractions.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM.Abstractions/MLib3.MVVM.Abstractions.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-mvvm-navigation.ps1
+++ b/build-nuget-mlib3-mvvm-navigation.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM.Navigation/MLib3.MVVM.Navigation.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-mvvm-sourcegenerators.ps1
+++ b/build-nuget-mlib3-mvvm-sourcegenerators.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM.SourceGenerators/MLib3.MVVM.SourceGenerators.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-mvvm.ps1
+++ b/build-nuget-mlib3-mvvm.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM/MLib3.MVVM.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-protocols-measurements-serialization-json.ps1
+++ b/build-nuget-mlib3-protocols-measurements-serialization-json.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Protocols.Measurements.Serialization.Json/MLib3.Protocols.Measurements.Serialization.Json.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-protocols-measurements-serialization-xml.ps1
+++ b/build-nuget-mlib3-protocols-measurements-serialization-xml.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Protocols.Measurements.Serialization.Xml/MLib3.Protocols.Measurements.Serialization.Xml.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-protocols-measurements-serialization.ps1
+++ b/build-nuget-mlib3-protocols-measurements-serialization.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Protocols.Measurements.Serialization/MLib3.Protocols.Measurements.Serialization.csproj" -ApiKey $ApiKey

--- a/build-nuget-mlib3-protocols-measurements.ps1
+++ b/build-nuget-mlib3-protocols-measurements.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ApiKey,
+    [string]$ApiKey
 )
 
 & ./build-nuget-base.ps1 -ProjectPath "src/MLib3.Protocols.Measurements/MLib3.Protocols.Measurements.csproj" -ApiKey $ApiKey


### PR DESCRIPTION
build-nuget-mlib3-aspdotnet-apikeys:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-aspdotnet-apikeys-abstractions:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-aspnetcore-dockercompose:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-communication-messagebroker:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-communication-messagebroker-abstractions:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-mvvm:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-mvvm-abstractions:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-mvvm-navigation:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-mvvm-sourcegenerators:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-protocols-measurements:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-protocols-measurements-serialization:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-protocols-measurements-serialization-json:
- Remove unnecessary line break in ApiKey parameter

build-nuget-mlib3-protocols-measurements-serialization-xml:
- Remove unnecessary line break in ApiKey parameter

This change improves the consistency of parameter definitions across multiple build scripts, ensuring cleaner code and easier maintenance.