### PR TITLE
feat(MVVM): include README.md in project packaging

### DIFF
--- a/src/MLib3.MVVM.Abstractions/MLib3.MVVM.Abstractions.csproj
+++ b/src/MLib3.MVVM.Abstractions/MLib3.MVVM.Abstractions.csproj
@@ -24,6 +24,10 @@
         <PackagePath></PackagePath>
         <Link>icon.png</Link>
       </None>
+      <None Include="README.md">
+        <Pack>True</Pack>
+        <PackagePath></PackagePath>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/src/MLib3.MVVM.Navigation/MLib3.MVVM.Navigation.csproj
+++ b/src/MLib3.MVVM.Navigation/MLib3.MVVM.Navigation.csproj
@@ -33,6 +33,10 @@
         <PackagePath></PackagePath>
         <Link>icon.png</Link>
       </None>
+      <None Include="README.md">
+        <Pack>True</Pack>
+        <PackagePath></PackagePath>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/src/MLib3.MVVM/MLib3.MVVM.csproj
+++ b/src/MLib3.MVVM/MLib3.MVVM.csproj
@@ -32,6 +32,10 @@
         <PackagePath></PackagePath>
         <Link>icon.png</Link>
       </None>
+      <None Include="README.md">
+        <Pack>True</Pack>
+        <PackagePath></PackagePath>
+      </None>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
MLib3.MVVM.Abstractions:
- Add README.md to project packaging

MLib3.MVVM:
- Add README.md to project packaging

MLib3.MVVM.Navigation:
- Add README.md to project packaging

Ensures README.md is included in the package for better documentation accessibility.