### PR TITLE
feat(deployment): add deployment scripts for MLib3 navigation packages

### DIFF
--- a/deploy-nuget-mlib3-mvvm-navigation.generator.ps1
+++ b/deploy-nuget-mlib3-mvvm-navigation.generator.ps1
@@ -1,0 +1,6 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ApiKey
+)
+
+& .\deploy-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM.Navigation.Generator/MLib3.MVVM.Navigation.Generator.csproj" -ApiKey $ApiKey

--- a/deploy-nuget-mlib3-mvvm-navigation.sourcegenerated.ps1
+++ b/deploy-nuget-mlib3-mvvm-navigation.sourcegenerated.ps1
@@ -1,0 +1,6 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ApiKey
+)
+
+& .\deploy-nuget-base.ps1 -ProjectPath "src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj" -ApiKey $ApiKey


### PR DESCRIPTION
- Added `deploy-nuget-mlib3-mvvm-navigation.sourcegenerated.ps1` to deploy the `MLib3.MVVM.Navigation.SourceGenerated` package.
- Added `deploy-nuget-mlib3-mvvm-navigation.generator.ps1` to deploy the `MLib3.MVVM.Navigation.Generator` package.
- Scripts support mandatory `ApiKey` parameter and invoke `deploy-nuget-base.ps1` with the appropriate project path.

Improves deployment automation for individual navigation-related NuGet packages.