### PR TITLE
project(Navigation): replace PackageReferences with ProjectReferences

### DIFF
--- a/.github/workflows/build-and-test-pull-request.yml
+++ b/.github/workflows/build-and-test-pull-request.yml
@@ -14,12 +14,14 @@ jobs:
     runs-on:  ubuntu-latest
 
     steps: 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name:  Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
         
     - name: Clear NuGet cache
       run:  dotnet nuget locals all --clear
@@ -27,18 +29,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore --verbosity detailed
       
-    - name:  Verify AwesomeAssertions package
-      run: |
-        echo "Checking if AwesomeAssertions was restored..."
-        find ~/. nuget/packages -name "AwesomeAssertions*" || echo "AwesomeAssertions not found in cache"
-      
     - name: Build
       run: dotnet build --no-restore --verbosity detailed
       
-    - name: List test project output
-      run: |
-        echo "Listing MLib3.System.UnitTests bin folder..."
-        ls -la tests/MLib3.System.UnitTests/bin/Debug/net8.0/ || echo "Output directory not found"
-        
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/publish-packages-from-main.yml
+++ b/.github/workflows/publish-packages-from-main.yml
@@ -8,18 +8,24 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
         
     - name: Restore dependencies
       run: dotnet restore
@@ -34,5 +40,5 @@ jobs:
       run: dotnet nuget add source --username mrmorrandir --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/mrmorrandir/index.json"
       
     - name: Publish to GitHub packages
-      run: dotnet nuget push **\*.nupkg --source github --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+      run: dotnet nuget push "**/*.nupkg" --source github --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
         

--- a/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
+++ b/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
@@ -27,9 +27,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MLib3.MVVM.Navigation" Version="2.4.0" />
-        <PackageReference Include="MLib3.MVVM.Navigation.Generator" 
-                          Version="2.4.0" 
+        <ProjectReference Include="..\MLib3.MVVM.Navigation\MLib3.MVVM.Navigation.csproj" />
+        <ProjectReference Include="..\MLib3.MVVM.Navigation.Generator\MLib3.MVVM.Navigation.Generator.csproj"
                           OutputItemType="Analyzer"
                           ReferenceOutputAssembly="false" />
     </ItemGroup>

--- a/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
+++ b/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
@@ -33,4 +33,10 @@
                           ReferenceOutputAssembly="false" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="..\MLib3.MVVM.Navigation.Generator\bin\$(Configuration)\netstandard2.0\MLib3.MVVM.Navigation.Generator.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Updated `MLib3.MVVM.Navigation.SourceGenerated` project to use `ProjectReference` in place of `PackageReference` for `MLib3.MVVM.Navigation` and `MLib3.MVVM.Navigation.Generator`.
- Ensures local project dependencies are referenced directly, improving development workflow and reducing dependency on externally published package versions.