### PR TITLE
feat(Navigation): bump version to 2.5.0 for all projects

### DIFF
--- a/src/MLib3.MVVM.Navigation.Generator/MLib3.MVVM.Navigation.Generator.csproj
+++ b/src/MLib3.MVVM.Navigation.Generator/MLib3.MVVM.Navigation.Generator.csproj
@@ -22,7 +22,7 @@
         <!-- Build-Output is not included, because the source generator is not needed at runtime, only at compile time.-->
         <!-- Therefore the output must go to the analyzers/dotnet/cs folder of the NuGet package, so that the compiler can find it. (see below)-->
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <PackageTags>MVVM;Navigation;ViewModels</PackageTags>
     </PropertyGroup>
 

--- a/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
+++ b/src/MLib3.MVVM.Navigation.SourceGenerated/MLib3.MVVM.Navigation.SourceGenerated.csproj
@@ -13,7 +13,7 @@
         <RepositoryUrl>https://github.com/mrmorrandir/MLib3</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <PackageTags>MVVM;Navigation;ViewModels</PackageTags>
         <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     </PropertyGroup>

--- a/src/MLib3.MVVM.Navigation/MLib3.MVVM.Navigation.csproj
+++ b/src/MLib3.MVVM.Navigation/MLib3.MVVM.Navigation.csproj
@@ -12,7 +12,7 @@
         <RepositoryUrl>https://github.com/mrmorrandir/MLib3</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <PackageTags>MVVM;Navigation;ViewModels</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>


### PR DESCRIPTION
- Updated `MLib3.MVVM.Navigation`, `MLib3.MVVM.Navigation.SourceGenerated`, and `MLib3.MVVM.Navigation.Generator` projects to version 2.5.0 in their respective `.csproj` files.
- Ensures alignment for upcoming release and compatibility across the solution.